### PR TITLE
Hubot HEROKU Keepalive

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -10,5 +10,6 @@
   "hubot-youtube",
   "hubot-ambush",
   "hubot-plusplus",
-  "hubot-factoids"
+  "hubot-factoids",
+  "hubot-heroku-keepalive"
 ]

--- a/node_modules/hubot-heroku-keepalive/package.json
+++ b/node_modules/hubot-heroku-keepalive/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/hubot-scripts/hubot-heroku-keepalive",
   "_id": "hubot-heroku-keepalive@0.0.4",
   "_shasum": "ad44c102198b79e88c9c11ec610d2a4b4837cee7",
-  "_from": "hubot-heroku-keepalive@*",
+  "_from": "hubot-heroku-keepalive@0.0.4",
   "_npmVersion": "1.4.24",
   "_npmUser": {
     "name": "technicalpickles",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Charles Butler <chuck@dasroot.net>",
   "description": "I do things sometimes",
   "dependencies": {
+    "htmlparser": "^1.7.6",
     "hubot": "^2.12.0",
     "hubot-ambush": "0.0.3",
     "hubot-diagnostics": "0.0.1",
@@ -22,8 +23,7 @@
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.3.0",
-    "hubot-youtube": "^0.1.2",
-    "htmlparser": "^1.7.6"
+    "hubot-youtube": "^0.1.2"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Depends on 2 ENV vars in the HEROKU DYNO

HUBOT_HEROKU_KEEPALIVE_URL - the URL to keepalive
HUBOT_HEROKU_KEEPALIVE_INTERVAL - the interval in which to keepalive, in minutes

Make sure to enable these before upstream deployment