### PR TITLE
Adds EXEC target for Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,10 +13,16 @@ module.exports = function(grunt) {
             },
             all: ['scripts/*.coffee']
         },
+        exec: {
+            hubot: 'bin/hubot -t',
+            npm_purge: 'rm -rf node_modules/*',
+        }
     });
 
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-coffeelint');
+    grunt.loadNpmTasks('grunt-exec');
 
-    grunt.registerTask('default', ['jshint', 'coffeelint']);
+
+    grunt.registerTask('default', ['jshint', 'coffeelint', 'exec']);
 };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-coffeelint": "~0.0.13",
     "grunt-contrib-jshint": "~0.10.0",
-    "grunt-coffeelint": "~0.0.13"
+    "grunt-exec": "^0.4.6"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Kicks off the hubot configuration checker, and wipes the npm_modules
directory so we ensure a fresh install on each run